### PR TITLE
Add cookie integration and multi download tab

### DIFF
--- a/src/ui/download_tab.py
+++ b/src/ui/download_tab.py
@@ -297,6 +297,12 @@ class DownloadTab(QWidget):
         self.use_cookie_checkbox = QRadioButton("使用Cookie")
         self.use_cookie_checkbox.setChecked(False)
         cookie_layout.addWidget(self.use_cookie_checkbox)
+
+        # 按钮：获取浏览器 Cookie
+        self.fetch_cookie_button = QPushButton("获取Cookie")
+        self.fetch_cookie_button.clicked.connect(self.fetch_cookies)
+        cookie_layout.addWidget(self.fetch_cookie_button)
+
         cookie_layout.addStretch()
         options_layout.addLayout(cookie_layout)
         
@@ -387,10 +393,10 @@ class DownloadTab(QWidget):
             
             # 创建并启动视频信息获取线程
             self.video_info_thread = VideoInfoThread(
-                self.video_info_parser, 
+                self.video_info_parser,
                 url,
                 use_cookies=self.use_cookie_checkbox.isChecked(),
-                cookies_file=self.cookie_manager.get_cookie_file() if self.use_cookie_checkbox.isChecked() else None
+                cookies_file=self.cookie_tab.get_cookie_file() if self.use_cookie_checkbox.isChecked() else None
             )
             self.video_info_thread.info_retrieved.connect(self.on_video_info_retrieved)
             self.video_info_thread.error_occurred.connect(self.on_video_info_error)
@@ -487,7 +493,7 @@ class DownloadTab(QWidget):
                 video_format_id=video_format_id,
                 audio_format_id=audio_format_id,
                 use_cookies=self.use_cookie_checkbox.isChecked(),
-                cookies_file=self.cookie_manager.get_cookie_file() if self.use_cookie_checkbox.isChecked() else None,
+                cookies_file=self.cookie_tab.get_cookie_file() if self.use_cookie_checkbox.isChecked() else None,
                 prefer_mp4=True  # 默认优先选择MP4格式
             )
             
@@ -583,3 +589,8 @@ class DownloadTab(QWidget):
         if dir_path:
             self.dir_input.setText(dir_path)
             self.config_manager.set('download_dir', dir_path)
+
+    def fetch_cookies(self):
+        """从 Cookie 标签页获取浏览器 Cookie"""
+        if self.cookie_tab:
+            self.cookie_tab.get_youtube_cookies()

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -20,6 +20,7 @@ from PyQt5.QtGui import QIcon, QFont, QPixmap
 
 # 导入自定义模块
 from src.ui.download_tab import DownloadTab
+from src.ui.multi_download_tab import MultiDownloadTab
 from src.ui.version_tab import VersionTab
 from src.core.version_manager import VersionManager
 from src.utils.logger import LoggerManager
@@ -232,10 +233,12 @@ class MainWindow(QMainWindow):
         # 创建下载标签页
         self.cookie_tab = CookieTab(self.status_bar)
         self.download_tab = DownloadTab(self.config_manager, self.status_bar, self.cookie_tab)
+        self.multi_download_tab = MultiDownloadTab(self.config_manager, self.status_bar, self.cookie_tab)
         self.version_tab = VersionTab(self.status_bar, auto_check=False)
         
         # 添加标签页
         self.tab_widget.addTab(self.download_tab, "下载")
+        self.tab_widget.addTab(self.multi_download_tab, "批量下载")
         self.tab_widget.addTab(self.cookie_tab, "Cookie")
         self.tab_widget.addTab(self.version_tab, "版本")
         

--- a/src/ui/multi_download_tab.py
+++ b/src/ui/multi_download_tab.py
@@ -1,0 +1,148 @@
+from PyQt5.QtWidgets import (
+    QWidget, QVBoxLayout, QHBoxLayout, QLabel, QPushButton, QTextEdit,
+    QProgressBar, QFileDialog, QRadioButton, QComboBox, QMessageBox, QGroupBox,
+    QLineEdit
+)
+from PyQt5.QtCore import Qt
+import os
+
+from src.core.downloader import VideoDownloader
+from src.core.video_info.video_info_parser import VideoInfoParser
+from src.utils.config import ConfigManager
+from src.utils.logger import LoggerManager
+
+class MultiDownloadTab(QWidget):
+    """多视频下载标签页"""
+
+    def __init__(self, config_manager: ConfigManager, status_bar=None, cookie_tab=None):
+        super().__init__()
+        self.config_manager = config_manager
+        self.status_bar = status_bar
+        self.cookie_tab = cookie_tab
+
+        self.logger = LoggerManager().get_logger()
+
+        self.downloader = VideoDownloader()
+        self.video_info_parser = VideoInfoParser()
+
+        self.init_ui()
+
+    def init_ui(self):
+        layout = QVBoxLayout(self)
+
+        input_group = QGroupBox("视频链接 (每行一个)")
+        input_layout = QVBoxLayout(input_group)
+        self.url_input = QTextEdit()
+        self.url_input.setPlaceholderText("在此输入多个链接...\n每行一个")
+        input_layout.addWidget(self.url_input)
+        parse_button = QPushButton("解析视频信息")
+        parse_button.clicked.connect(self.parse_video_info)
+        input_layout.addWidget(parse_button)
+        layout.addWidget(input_group)
+
+        options_group = QGroupBox("下载选项")
+        options_layout = QVBoxLayout(options_group)
+        quality_layout = QHBoxLayout()
+        quality_layout.addWidget(QLabel("视频质量:"))
+        self.video_quality_combo = QComboBox()
+        quality_layout.addWidget(self.video_quality_combo)
+        options_layout.addLayout(quality_layout)
+
+        cookie_layout = QHBoxLayout()
+        self.use_cookie_checkbox = QRadioButton("使用Cookie")
+        cookie_layout.addWidget(self.use_cookie_checkbox)
+        fetch_btn = QPushButton("获取Cookie")
+        fetch_btn.clicked.connect(self.fetch_cookies)
+        cookie_layout.addWidget(fetch_btn)
+        cookie_layout.addStretch()
+        options_layout.addLayout(cookie_layout)
+
+        dir_layout = QHBoxLayout()
+        dir_layout.addWidget(QLabel("下载目录:"))
+        self.dir_input = QLineEdit()
+        self.dir_input.setReadOnly(True)
+        dir_layout.addWidget(self.dir_input)
+        browse_btn = QPushButton("浏览")
+        browse_btn.clicked.connect(self.browse_download_dir)
+        dir_layout.addWidget(browse_btn)
+        options_layout.addLayout(dir_layout)
+
+        layout.addWidget(options_group)
+
+        progress_group = QGroupBox("下载进度")
+        progress_layout = QVBoxLayout(progress_group)
+        self.progress_bar = QProgressBar()
+        progress_layout.addWidget(self.progress_bar)
+        self.status_label = QLabel("就绪")
+        progress_layout.addWidget(self.status_label)
+        layout.addWidget(progress_group)
+
+        btn_layout = QHBoxLayout()
+        self.download_button = QPushButton("开始下载")
+        self.download_button.clicked.connect(self.start_download)
+        btn_layout.addWidget(self.download_button)
+        layout.addLayout(btn_layout)
+
+        self.set_default_download_dir()
+
+    def update_status_message(self, message: str):
+        if self.status_bar:
+            self.status_bar.showMessage(message)
+
+    def parse_video_info(self):
+        urls = [u.strip() for u in self.url_input.toPlainText().splitlines() if u.strip()]
+        if not urls:
+            QMessageBox.warning(self, "错误", "请输入至少一个视频链接")
+            return
+        # 解析第一条链接用于获取可用格式
+        try:
+            info = self.video_info_parser.parse_video(urls[0])
+            formats = self.video_info_parser.get_available_formats(info)
+            formatted = self.video_info_parser.get_formatted_formats(formats)
+            self.video_quality_combo.clear()
+            self.video_quality_combo.addItem("最高画质 (自动)", "best")
+            for f in formatted:
+                if f['type'] == 'video':
+                    self.video_quality_combo.addItem(f['display'], f['format_id'])
+            self.status_label.setText(f"解析完成，共 {len(urls)} 条链接")
+            self.update_status_message("解析完成")
+        except Exception as e:
+            QMessageBox.critical(self, "错误", f"解析失败: {str(e)}")
+            self.status_label.setText("解析失败")
+
+    def start_download(self):
+        urls = [u.strip() for u in self.url_input.toPlainText().splitlines() if u.strip()]
+        if not urls:
+            QMessageBox.warning(self, "错误", "请输入视频链接")
+            return
+        output_dir = self.dir_input.text()
+        if not output_dir:
+            QMessageBox.warning(self, "错误", "请选择下载目录")
+            return
+        format_id = self.video_quality_combo.currentData() or 'best'
+        self.status_label.setText("开始下载...")
+        self.update_status_message("开始下载")
+        use_ck = self.use_cookie_checkbox.isChecked()
+        cookie_file = self.cookie_tab.get_cookie_file() if use_ck and self.cookie_tab else None
+        self.downloader.download_videos(urls, output_dir, format_id=format_id,
+                                        use_cookies=use_ck, cookies_file=cookie_file)
+        self.status_label.setText("下载完成")
+        self.update_status_message("下载完成")
+
+    def browse_download_dir(self):
+        current_dir = self.dir_input.text() or os.path.join(os.path.expanduser('~'), 'Desktop')
+        dir_path = QFileDialog.getExistingDirectory(self, "选择下载文件夹", current_dir)
+        if dir_path:
+            self.dir_input.setText(dir_path)
+            self.config_manager.set('download_dir', dir_path)
+
+    def set_default_download_dir(self):
+        last_dir = self.config_manager.get('download_dir') or os.path.join(os.path.expanduser('~'), 'Desktop')
+        if not os.path.exists(last_dir):
+            last_dir = os.path.join(os.path.expanduser('~'), 'Desktop')
+        self.dir_input.setText(last_dir)
+        self.config_manager.set('download_dir', last_dir)
+
+    def fetch_cookies(self):
+        if self.cookie_tab:
+            self.cookie_tab.get_youtube_cookies()


### PR DESCRIPTION
## Summary
- integrate CookieTab in download workflow
- add a button in Download tab to fetch cookies
- create MultiDownloadTab for downloading multiple videos
- register new tab in main window

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_685583b45e588321b1a5212cbba9f8a6